### PR TITLE
Updates Eclipse and Postman versions

### DIFF
--- a/workstation_versions.yml
+++ b/workstation_versions.yml
@@ -18,7 +18,7 @@ minikube_version: 0.22.1
 
 #Eclipse
 eclipse_version: oxygen
-eclipse_sr: R
+eclipse_sr: 1a
 lombok_version: 1.16.18
 eclim_version: 2.7.0
 
@@ -50,7 +50,7 @@ netbeans_build: 201609300101
 pencil_version: 3.0.0-rc.1
 
 #Postman
-postman_version: 5.2.0
+postman_version: 5.3.0
 
 #RatPoison
 


### PR DESCRIPTION
JUnit 5 fully available in Eclipse Oxygen release 1a!

Also threw in the latest Postman update.