### PR TITLE
Fixes JMeter move directory task

### DIFF
--- a/roles/jmeter/tasks/main.yml
+++ b/roles/jmeter/tasks/main.yml
@@ -28,7 +28,10 @@
 
 - name: "move the tar file's base directory somewhere maintainable"
   command:
-    mv "{{ jmeter_tar_directory }}" "{{ jmeter_home_directory }}"
+    argv:
+      - "mv"
+      - "{{ jmeter_tar_directory }}"
+      - "{{ jmeter_home_directory }}"
   when: "unarchive_result is changed"
   tags:
   - "jmeter"

--- a/roles/jmeter/tasks/main.yml
+++ b/roles/jmeter/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: "move the tar file's base directory somewhere maintainable"
   command:
-    mv: "{{ jmeter_tar_directory }} {{ jmeter_home_directory }}"
+    mv "{{ jmeter_tar_directory }}" "{{ jmeter_home_directory }}"
   when: "unarchive_result is changed"
   tags:
   - "jmeter"


### PR DESCRIPTION
JMeter move directory task was failing. The mv in the command task should not have had ":" after it. Also added quotations around the bracketed variables.
Issue #120